### PR TITLE
Fix add_log error cluster merging.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ impl LogCluster {
     fn add_log(&mut self, log: &[Token]) {
         for (i, token) in log.iter().enumerate() {
             if token != &Token::WildCard {
-                let other_token = &log[i];
+                let other_token = &self.log_tokens[i];
                 if token != other_token {
                     self.log_tokens[i] = Token::WildCard;
                 }


### PR DESCRIPTION
Hello,

thx for this rust implementation for drain.
This commit fixes add_log function. We should not compare the new tokens with itself but with the log LogCluster tokens instead.
Otherwise Wildcards are never created by drain :+1: 

![image](https://user-images.githubusercontent.com/5711608/144494934-8893cc31-7bb9-44f4-9c9c-897b4b4e0f05.png)

On the left output without the fix, on the right with the fix and the correct wildcards in the log cluster definition.
Below the test case.
```
1 2 3 4 portal user authentication succeeded. Login from: 1.1.1.1 Source region: FR User name: Tom Auth type: NTLM OS version: Microsoft Windows10
2 3 4 4 portal user authentication succeeded. Login from: 2.3.1.1 Source region: US User name: Sam Auth type: NTLM OS version: Microsoft Windows10
2 3 5 4 portal user authentication succeeded. Login from: 3.3.1.1 Source region: IN User name: Dora Auth type: NTLM OS version: Microsoft Windows10
2 3 5 4 portal user authentication succeeded. Login from: 4.2.1.1 Source region: DE User name: Admin Auth type: NTLM OS version: Microsoft Windows10
```

Have a nice day.
@chaignc